### PR TITLE
add kde 2D and remove hexbin

### DIFF
--- a/bomeba0/visualization/plots.py
+++ b/bomeba0/visualization/plots.py
@@ -2,18 +2,23 @@
 A collections of plots
 """
 import matplotlib.pyplot as plt
+from .kde import plot_kde
 
 
-def plot_ramachandran(pose, scatter=True, ax=None):
+def plot_ramachandran(pose, kind='scatter', contour=True, scatter_kwargs=None, ax=None):
     """
     Ramachandran plot
 
     Parameters
     ----------
     pose : protein object
-    scatter : boolean
-    if True return a scatter plot, if False a hexbin plot
-    default True
+    kind : str
+        Acepted values as `scatter`, `kde` or `sca+kde`. Defaults to scatter
+    alpha : float
+        opacity level, should be between 0 (transparent) to 1 (opaque), only works with `kind=scatter`
+    contour : bool
+        If True plot the 2D KDE using contours, otherwise plot a smooth 2D KDE. Defaults to True.
+        Only works for `kind=kde`
     ax : axes
         Matplotlib axes. Defaults to None.
 
@@ -22,7 +27,9 @@ def plot_ramachandran(pose, scatter=True, ax=None):
     ax : matplotlib axes
     """
     if ax is None:
-        _, ax = plt.subplots()
+        ax = plt.gca()
+    if scatter_kwargs == None:
+        scatter_kwargs = {}
 
     phi = []
     psi = []
@@ -30,14 +37,18 @@ def plot_ramachandran(pose, scatter=True, ax=None):
         phi.append(pose.get_phi(i))
         psi.append(pose.get_psi(i))
 
-    if scatter:
-        ax.scatter(phi, psi)
+    if kind not in ['scatter', 'kde', 'sca+kde']:
+        raise ValueError(f"kind should be 'scatter', 'hexbin' or 'kde'not {kind}")
+
+    if kind == 'scatter':
+        ax.scatter(phi, psi, **scatter_kwargs)
+    elif kind == 'kde':
+        plot_kde(phi, psi, contour, ax=ax)
     else:
-        gridsize = 100
-        #gridsize = int(2*len(phi)**(1/3))
-        # if gridsize < 36:
-        #    gridsize = 36
-        ax.hexbin(phi, psi, gridsize=gridsize, cmap=plt.cm.summer, mincnt=1)
+        scatter_kwargs.setdefault("marker", ".")
+        scatter_kwargs.setdefault("color", "k")
+        plot_kde(phi, psi, contour, ax=ax)
+        ax.scatter(phi, psi, **scatter_kwargs)
 
     ax.set_xlabel('$\phi$', fontsize=16)
     ax.set_ylabel('$\psi$', fontsize=16, rotation=0)


### PR DESCRIPTION
`bmb.plot_ramachandran(prot, kind='scatter')`

![scatter](https://user-images.githubusercontent.com/1338958/50179458-d7a21200-02e5-11e9-9108-111c19fed1bc.png)


`bmb.plot_ramachandran(prot, kind='kde')`

![kde](https://user-images.githubusercontent.com/1338958/50179463-dbce2f80-02e5-11e9-8ecb-0425a0a7e8da.png)


`bmb.plot_ramachandran(prot, kind='sca+kde')`

![sca_kde](https://user-images.githubusercontent.com/1338958/50179467-de308980-02e5-11e9-8bb1-eddc5ce43ea9.png)

There is a new `contour` argument
`bmb.plot_ramachandran(prot, kind='sca+kde', contour=False)`
![kde_1](https://user-images.githubusercontent.com/1338958/50179564-1768f980-02e6-11e9-9ac2-9afd29f286be.png)

and also a `scatter_kwargs` argument.
`bmb.plot_ramachandran(prot, kind='scatter', scatter_kwargs={'alpha':'0.5'})`
![scatter_1](https://user-images.githubusercontent.com/1338958/50179645-5303c380-02e6-11e9-8f34-8b5e6f7dbab5.png)



